### PR TITLE
fix local filesystem not yielding iterator vs iceberg interface who does

### DIFF
--- a/python_legacy/iceberg/core/filesystem/filesystem_table_operations.py
+++ b/python_legacy/iceberg/core/filesystem/filesystem_table_operations.py
@@ -17,6 +17,7 @@
 
 import logging
 from pathlib import Path
+from typing import Iterator
 import uuid
 
 from iceberg.exceptions import CommitFailedException, ValidationException
@@ -127,7 +128,10 @@ class FilesystemTableOperations(TableOperations):
         else:
             with fs.open(version_hint_file, "r") as fo:
                 # return int(fo.readline().replace("\n", ""))
-                return int(next(fo.readline()))
+                line = fo.readline()
+                if isinstance(line, Iterator):
+                    return int(next(line))
+                return int(line)
 
     def write_version_hint(self, version):
         version_hint_file = str(self.version_hint_file())


### PR DESCRIPTION
Iceberg support 3 types of file storage:

1. Local FS: uses native Python objects
2. S3: uses S3File interface that [returns a generator ](https://github.com/acryldata/py-iceberg/blob/main/python_legacy/iceberg/core/filesystem/s3_filesystem.py#L224-L228) for `readline()`
3. ABFSS: uses AbfssFile interface that [returns a generator ](https://github.com/acryldata/py-iceberg/blob/main/python_legacy/iceberg/core/filesystem/abfss_filesystem.py#L143-L148) for `readline()`

When local fs is used, `readline()` is returning a `str` and not an `Iterator`, so the code is crashing.  `read_version_hint()` is the only function using `readline()`, so I am patching it to make it work.  The real fix would require to port local fs to the same interface as S3 and Abfss, but this is out of scope for now.
